### PR TITLE
Callable type hinting not supported in PHP 5.3

### DIFF
--- a/src/MailchimpExport/CampaignSubscriberActivity.php
+++ b/src/MailchimpExport/CampaignSubscriberActivity.php
@@ -20,7 +20,7 @@ class MailchimpExport_CampaignSubscriberActivity implements MailchimpExport_Data
      * @param null $since only return orders with order dates since a GMT timestamp – in YYYY-MM-DD HH:mm:ss format
      * @return string
      */
-    public function export(callable $callable, $id, $includeEmpty = false, $since = null) {
+    public function export($callable, $id, $includeEmpty = false, $since = null) {
         $_params = array("id" => $id, "include_empty" => $includeEmpty, "since" => $since);
         $this->callable = $callable;
         $this->master->call('campaignSubscriberActivity/', $_params, $this);

--- a/src/MailchimpExport/Lists.php
+++ b/src/MailchimpExport/Lists.php
@@ -27,7 +27,7 @@ class MailchimpExport_Lists implements MailchimpExport_DataCallbackInterface {
      * @param null $hashed if, instead of full list data, you'd prefer a hashed list of email addresses, set this to the hashing algorithm you expect. Currently only "sha256" is supported.
      * @throws MailchimpExport_NoCallableError
      */
-    public function export(callable $callable, $id, $status = self::STATUS_SUBSCRIBED, array $segment = array(), $since = null, $hashed = null) {
+    public function export($callable, $id, $status = self::STATUS_SUBSCRIBED, array $segment = array(), $since = null, $hashed = null) {
 
         $_params = array("id" => $id, "status" => $status, "segment" => $segment, "since" => $since, 'hashed' => $hashed);
         $this->callable = $callable;


### PR DESCRIPTION
Have added support for PHP 5.3 by removing 'callable' type hinting