### PR TITLE
Fix bug when Mailchimps gives a smaller array of data because of miss…

### DIFF
--- a/src/MailchimpExport.php
+++ b/src/MailchimpExport.php
@@ -216,6 +216,12 @@ class MailchimpExport
 
             // if we have headings => combine them with the dataset
             if ($headings !== null) {
+                // Sometimes mailchimps gives an smaller array of data because of missing data.
+                // This will cause an error in array_column
+                while(count($headings) > count($currentDataSet)){
+                    $currentDataSet[]= null;
+                }
+                
                 $returnValue = array_combine($headings, $currentDataSet);
             } else {
                 $returnValue = $currentDataSet;


### PR DESCRIPTION
Hello,

I was importing a really big database of subscribers from Mailchimp.
And I came to an issue, when Mailchimp gives you less data than in headers, for some columns.
This happens only for some users, and you would have to go into an interface and fix them, by deleting and putting them back. It is ok as it happens not so often.
But when you have some synchronization with it, it is a big problem.
I fixed this locally just by adding some empty data to the row.
I have checked that missing data is in the end of the line so it will not cause a problem.

Hope you find my changes useful.